### PR TITLE
1.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog / CHANGELOG
 
 
+### 1.1.2 (2019-01-22)
+
+* Update: Eslint package `5.12.0` → `5.12.1`
+* Update: Node minimum version `>=8.10.0` → `>=8.9.0`
+
+
 ### 1.1.1 (2019-01-22)
 
 * Edit: `package.json` script shortcut based on `deptagency` namespace

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deptagency/changelog",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Magically creates a YML file with metadata of a change entry",
   "main": "index.js",
   "files": [
@@ -9,7 +9,7 @@
   "license": "MIT",
   "dependencies": {
     "enquirer": "^2.2.0",
-    "eslint": "^5.12.0",
+    "eslint": "^5.12.1",
     "eslint-plugin-node": "^8.0.1",
     "eslint-plugin-security": "^1.4.0",
     "slugify": "^1.3.4",
@@ -26,7 +26,7 @@
     "test": "eslint ."
   },
   "engines": {
-    "node": ">=8.10.0"
+    "node": ">=8.9.0"
   },
   "repository": "deptagency/changelog",
   "author": "Dept Design & Technology GmbH"

--- a/yarn.lock
+++ b/yarn.lock
@@ -195,9 +195,9 @@ eslint-visitor-keys@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#3f3180fb2e291017716acb4c9d6d5b5c34a6a81d"
 
-eslint@^5.12.0:
-  version "5.12.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-5.12.0.tgz#fab3b908f60c52671fb14e996a450b96c743c859"
+eslint@^5.12.1:
+  version "5.12.1"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-5.12.1.tgz#5ca9931fb9029d04e7be92b03ce3b58edfac7e3b"
   dependencies:
     "@babel/code-frame" "^7.0.0"
     ajv "^6.5.3"
@@ -566,8 +566,8 @@ resolve-from@^4.0.0:
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
 
 resolve@^1.8.1:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.9.0.tgz#a14c6fdfa8f92a7df1d996cb7105fa744658ea06"
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.10.0.tgz#3bdaaeaf45cc07f375656dfd2e54ed0810b101ba"
   dependencies:
     path-parse "^1.0.6"
 


### PR DESCRIPTION
* Update: Eslint package `5.12.0` → `5.12.1`
* Update: Node minimum version `>=8.10.0` → `>=8.9.0`